### PR TITLE
remove guard clause

### DIFF
--- a/app/services/file_ingestor.rb
+++ b/app/services/file_ingestor.rb
@@ -125,8 +125,6 @@ class FileIngestor
 
       csv = CSV.read(file, headers: true)
       csv.each do |row|
-        next if Person.find_by(name: row['name']) # GUARD! IS TOO STRICT!
-
         person = RecordPerson.call(row['name'])
         print 'p'
 

--- a/app/views/home/index_view.rb
+++ b/app/views/home/index_view.rb
@@ -28,6 +28,7 @@ class Home::IndexView < ApplicationView
       ul(style: 'list-style-type: none;') do
         li { a(href: 'https://transparency.aec.gov.au/AnnualDonor') { 'AEC Annual Donor records since 2018' } }
         li { a(href: 'https://transparency.aec.gov.au/ReferendumDonor') { 'AEC 2023 Referendum Donor Returns' } }
+        li { a(href: 'https://transparency.aec.gov.au/Donor') { 'AEC Election Donor Returns since 2007' } }
         li { a(href: 'https://en.wikipedia.org/wiki/Category:Members_of_Australian_parliaments_by_term') { 'Federal MPs and Senators since 2016' } }
       end
 

--- a/csv_data/other_people_groups_positions.csv
+++ b/csv_data/other_people_groups_positions.csv
@@ -5,9 +5,9 @@ Office of Josh Frydenberg,Martin Codina,Chief Of Staff,1/1/2015,1/8/2017,https:/
 Westpac BT Financial Group,Martin Codina,8/8/2017,1/9/2018,Head of Government and Industry Affairs,https://www.linkedin.com/in/martin-codina-32a1b641/
 Office of Josh Frydenberg,Martin Codina,Chief Of Staff,1/9/2018,22/5/2022,https://www.linkedin.com/in/martin-codina-32a1b641/
 Office of Josh Frydenberg,Josh Frydenburg
-ALP NSW, Adele Tahan
+ALP NSW, Adele Tahan, Member, , , https://usu.org.au/pledge2021/
 Warren Entsch Campaign, Warren Entsch, Candidate
-Warren Entsch Campaign, Trent Twomey, Campaign Director
+Warren Entsch Campaign, Trent Twomey, Campaign Director,,,https://www.ausdoc.com.au/news/ausdoc-investigation-pharmacy-guild-its-lobbyists-and-its-money/
 Barnaby's Maiden Speech, Barnaby Joyce, Speaker
 Barnaby's Maiden Speech, Gina Rinehart, Attendee
 Barnaby's Maiden Speech, Russell Webb, Attendee
@@ -52,7 +52,7 @@ Oryxium Investments Limited, David Lowy, Part Owner
 Oryxium Investments Limited, Peter Lowy, Part Owner
 Oryxium Investments Limited, Steven Lowy, Part Owner
 Australian Water Holdings Pty Ltd, Arthur Sinodinos, Chairman,1/1/2008,6/5/2011
-Australian Water Holdings Pty Ltd, Eddie Obeid Junior, Salaryman,1/1/2008,6/5/2011
+Australian Water Holdings Pty Ltd, Eddie Obeid Junior, ,1/1/2008,6/5/2011
 Australian Water Holdings Pty Ltd, Nick Di Giralomo, Chief Executive Officer, 1/1/2007, 31/12/2012, https://www.linkedin.com/in/nick-di-girolamo-bb2356194/details/experience/
 Colin Biggers and Paisley, Nick Di Giralomo, Partner, 1/1/1994, 31/12/2005, https://www.linkedin.com/in/nick-di-girolamo-bb2356194/details/experience/
 Hancock Prospecting Pty Ltd, Gina Rinehart, Executive Chairwoman
@@ -96,9 +96,9 @@ Gas Energy Australia
 Liberal National Party QLD, Trent Twomey, Party Member
 Advance Australia, Gerard Benedet, National Director, 1/3/2018, 1/10/2019, https://www.linkedin.com/in/gerard-benedet-759a83b4/
 Silver River Investment Holdings Pty Ltd, Elizabeth Fenwick, Owner,,, https://www.theleader.com.au/story/7602871/donations-flow-for-far-right-anti-covid-action-party/
-Silver River Investment Holdings Pty Ltd, Simon Fenwick, Owner, https://www.theleader.com.au/story/7602871/donations-flow-for-far-right-anti-covid-action-party/
-Cartwright Investment Corp Pty Ltd ATF Burleigh Trust, Elizabeth Fenwick, Owner, https://www.theleader.com.au/story/7602871/donations-flow-for-far-right-anti-covid-action-party/
-Bakers Delight, Roger Gillespie, Founder, https://www.dailymail.co.uk/news/article-13045657/Bakers-Delight-customers-refuse-woke-boycott.html
+Silver River Investment Holdings Pty Ltd, Simon Fenwick, Owner,,, https://www.theleader.com.au/story/7602871/donations-flow-for-far-right-anti-covid-action-party/
+Cartwright Investment Corp Pty Ltd ATF Burleigh Trust, Elizabeth Fenwick, Owner,,, https://www.theleader.com.au/story/7602871/donations-flow-for-far-right-anti-covid-action-party/
+Bakers Delight, Roger Gillespie, Founder,,, https://www.dailymail.co.uk/news/article-13045657/Bakers-Delight-customers-refuse-woke-boycott.html
 St Baker Enterprises, Trevor St-Baker, Owner
 The Trustee for ST Baker Family Trust, Trevor St-Baker, Owner
 Pesca Aviation, Steve Baxter,,,, https://www.afr.com/rich-list/the-heavy-hitters-behind-australia-s-biggest-conservative-lobby-group-20240201-p5f1pt


### PR DESCRIPTION
This guard clause was preventing federsl MPS from being recorded as federal MPS if they already excisted in the database
EG Gladys Liu and Helen Haines

Gladys Liu
Had _made_ donations, and thus already existed in the database

Helen Haines
Had _received_ donations, and thus already existed in the database


some minor corrections on evidence, which was in the wrong column of CSV