### PR TITLE
rename queue and use it for tender ingesting

### DIFF
--- a/app/sidekiq/build_group_cached_data_job.rb
+++ b/app/sidekiq/build_group_cached_data_job.rb
@@ -1,7 +1,7 @@
 class BuildGroupCachedDataJob
   include Sidekiq::Job
 
-  sidekiq_options queue: :cache_build, lock: :until_executed, on_conflict: :log
+  sidekiq_options queue: :low_concurrency, lock: :until_executed, on_conflict: :log
 
   def perform(id)
     group = Group.find_by(id:)

--- a/app/sidekiq/build_person_cached_data_job.rb
+++ b/app/sidekiq/build_person_cached_data_job.rb
@@ -1,7 +1,7 @@
 class BuildPersonCachedDataJob
   include Sidekiq::Job
 
-  sidekiq_options queue: :cache_build, lock: :until_executed, on_conflict: :log
+  sidekiq_options queue: :low_concurrency, lock: :until_executed, on_conflict: :log
 
   def perform(id)
     person = Person.find_by(id:)

--- a/app/sidekiq/ingest_contracts_url_job.rb
+++ b/app/sidekiq/ingest_contracts_url_job.rb
@@ -1,6 +1,8 @@
 class IngestContractsUrlJob
   include Sidekiq::Job
 
+  sidekiq_options queue: :low_concurrency, lock: :until_executed, on_conflict: :log
+
   def perform(url)
     TenderIngestor.process_for_url(url: url)
   rescue StandardError => e

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,3 +1,3 @@
 :queues:
   - [default, 5]       # default queue, concurrency 5
-  - [cache_build, 1]   # cache_build queue, concurrency 1
+  - [low_concurrency, 1]   # low_concurrency queue, concurrency 1


### PR DESCRIPTION
and lower the concurrency - tender ingesting does not need to be fast really. Better to save the load on the server by running only one job at a time