### PR TITLE
Switch robots.txt to an allowlist approach

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,16 @@
 # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 
+User-agent: Googlebot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: DuckDuckBot
+Allow: /
+
+User-agent: Applebot
+Allow: /
+
 User-agent: *
 Disallow: /


### PR DESCRIPTION
## Summary
- Replace the blanket `Disallow: /` in `public/robots.txt`, which blocked all crawlers (including Googlebot/Bingbot) from indexing the site, with an explicit allowlist for known search-indexing crawlers.
- Everything else, including AI scraping/training bots, remains denied by default.

Fixes #222

## Test plan
- [ ] Post-deploy: verify robots.txt behaves as intended (e.g. Google Search Console's robots.txt tester or a crawler-simulation check)