### PR TITLE
Bump Actions to Node 24 runtime, fix staging Node version

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -10,12 +10,12 @@ jobs:
     environment:
       name: staging
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install Node dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,10 +10,10 @@ jobs:
     environment:
       name: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/ruby_on_rails_ci.yml
+++ b/.github/workflows/ruby_on_rails_ci.yml
@@ -25,7 +25,7 @@ jobs:
       DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,6 @@
+# Rails derives the session cookie name from the app's module name only, so
+# every git worktree of this app (e.g. for parallel feature branches) shares
+# one cookie. Browser cookies aren't port-scoped, so two worktrees running on
+# different localhost ports stomp on each other's session/CSRF state. Scoping
+# the key to the worktree directory name gives each one its own cookie.
+Rails.application.config.session_store :cookie_store, key: "_sunshine01_session_#{Rails.root.basename}"


### PR DESCRIPTION
## Summary
- GitHub is deprecating the Node 20 runtime for Actions ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)) — Node 20 is fully removed fall 2026, default switches June 2026. `actions/checkout@v4` and `actions/setup-node@v4` are built on Node 20 and were already showing deprecation warnings on staging deploy runs.
- Bumps `actions/checkout` and `actions/setup-node` to `v7` (confirmed `using: node24` in each action's `action.yml`) across all three workflows.
- Fixes `deploy-staging.yml`'s `node-version` from `'18'` to `'22'`, matching `deploy.yml` and the Node ≥22.12 requirement for Vite 8/rolldown noted in CLAUDE.md. Staging was silently running asset builds on an unsupported Node version.
- Adds `config/initializers/session_store.rb` to scope the session cookie key to the worktree directory name. Running two git worktrees locally on different ports (e.g. main on :3100, a feature branch on :3101) previously shared one cookie name (`_sunshine01_session`), and since cookies aren't port-scoped, bouncing between them in the same browser clobbers the other's session/CSRF token — surfacing as `ActionController::InvalidAuthenticityToken` on ActiveAdmin login.

## Test plan
- [x] CI (`ruby_on_rails_ci.yml`) runs clean on this PR
- [x] Push to `staging` and confirm the deprecation warning is gone and asset build succeeds on Node 22
- [ ] Run two worktrees locally on different ports, log into `/admin` on each in the same browser, confirm no CSRF errors