### PR TITLE
OpenAustralia politician ingest — Increment 3a: schedule roster ingest, chain Interpretation

### DIFF
--- a/app/sidekiq/open_australia/ingest_current_politicians_job.rb
+++ b/app/sidekiq/open_australia/ingest_current_politicians_job.rb
@@ -1,0 +1,14 @@
+require 'sidekiq-scheduler'
+
+class OpenAustralia::IngestCurrentPoliticiansJob
+  include Sidekiq::Job
+
+  def perform
+    OpenAustralia::IngestCurrentPoliticians.call
+  rescue StandardError => e
+    Rails.logger.error "Error processing OpenAustralia::IngestCurrentPoliticiansJob: #{e.message} - will retry"
+    Rails.logger.error e.backtrace.join("\n")
+    ApiLog.create(message: e.message)
+    raise e
+  end
+end

--- a/app/sidekiq/open_australia/ingest_person_job.rb
+++ b/app/sidekiq/open_australia/ingest_person_job.rb
@@ -3,6 +3,7 @@ class OpenAustralia::IngestPersonJob
 
   def perform(person_id)
     person = OpenAustralia::IngestPerson.call(person_id:)
+    # IngestPerson returns nil when OpenAustralia has no terms for this person_id
     OpenAustralia::Interpretation::RecordMembershipsAndPositions.call(person:) if person
   rescue StandardError => e
     Rails.logger.error "Error processing OpenAustralia::IngestPersonJob: #{e.message} - will retry"

--- a/app/sidekiq/open_australia/ingest_person_job.rb
+++ b/app/sidekiq/open_australia/ingest_person_job.rb
@@ -2,7 +2,8 @@ class OpenAustralia::IngestPersonJob
   include Sidekiq::Job
 
   def perform(person_id)
-    OpenAustralia::IngestPerson.call(person_id:)
+    person = OpenAustralia::IngestPerson.call(person_id:)
+    OpenAustralia::Interpretation::RecordMembershipsAndPositions.call(person:) if person
   rescue StandardError => e
     Rails.logger.error "Error processing OpenAustralia::IngestPersonJob: #{e.message} - will retry"
     Rails.logger.error e.backtrace.join("\n")

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -65,6 +65,8 @@
     # Every month, re-fetch the current OpenAustralia roster and re-ingest each politician
     # (each per-person ingest also re-runs Interpretation, so this both discovers new
     # politicians and refreshes/closes terms for already-known ones still on the roster)
+    # Cron day is 4, not 5: per the conversion table above, hour 14 UTC rolls into the
+    # *next* AEST day, so day 4 is what actually lands at 00:00 AEST on the 5th.
     ingest_current_politicians_job:
       cron: '0 14 4 * *' # Every month on the 5th at midnight AEST
       class: OpenAustralia::IngestCurrentPoliticiansJob

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -66,5 +66,5 @@
     # (each per-person ingest also re-runs Interpretation, so this both discovers new
     # politicians and refreshes/closes terms for already-known ones still on the roster)
     ingest_current_politicians_job:
-      cron: '0 14 5 * *' # Every month on the 5th at midnight AEST
+      cron: '0 14 4 * *' # Every month on the 5th at midnight AEST
       class: OpenAustralia::IngestCurrentPoliticiansJob

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -62,3 +62,9 @@
     refresh_nodes_count_job:
       cron: '15 * * * *' # Every hour at 15 mins past the hour
       class: Cache::RefreshNodesCountJob
+    # Every month, re-fetch the current OpenAustralia roster and re-ingest each politician
+    # (each per-person ingest also re-runs Interpretation, so this both discovers new
+    # politicians and refreshes/closes terms for already-known ones still on the roster)
+    ingest_current_politicians_job:
+      cron: '0 14 5 * *' # Every month on the 5th at midnight AEST
+      class: OpenAustralia::IngestCurrentPoliticiansJob

--- a/spec/sidekiq/open_australia/ingest_current_politicians_job_spec.rb
+++ b/spec/sidekiq/open_australia/ingest_current_politicians_job_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe OpenAustralia::IngestCurrentPoliticiansJob, type: :job do
+  subject(:perform) { described_class.new.perform }
+
+  before do
+    allow(OpenAustralia::IngestCurrentPoliticians).to receive(:call)
+  end
+
+  it 'delegates to OpenAustralia::IngestCurrentPoliticians' do
+    perform
+    expect(OpenAustralia::IngestCurrentPoliticians).to have_received(:call)
+  end
+
+  context 'when it raises' do
+    before do
+      allow(OpenAustralia::IngestCurrentPoliticians).to receive(:call).and_raise(StandardError, 'boom')
+    end
+
+    it 're-raises and logs an ApiLog entry' do
+      expect { perform }.to raise_error(StandardError, 'boom').and change(ApiLog, :count).by(1)
+    end
+  end
+end

--- a/spec/sidekiq/open_australia/ingest_person_job_spec.rb
+++ b/spec/sidekiq/open_australia/ingest_person_job_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe OpenAustralia::IngestPersonJob, type: :job do
+  subject(:perform) { described_class.new.perform('10007') }
+
+  let(:person) { create(:person) }
+
+  before do
+    allow(OpenAustralia::IngestPerson).to receive(:call).with(person_id: '10007').and_return(person)
+    allow(OpenAustralia::Interpretation::RecordMembershipsAndPositions).to receive(:call)
+  end
+
+  it 'ingests the person' do
+    perform
+    expect(OpenAustralia::IngestPerson).to have_received(:call).with(person_id: '10007')
+  end
+
+  it 'runs Interpretation for the ingested person' do
+    perform
+    expect(OpenAustralia::Interpretation::RecordMembershipsAndPositions).to have_received(:call).with(person:)
+  end
+
+  context 'when ingest returns nil (no terms found for the person_id)' do
+    let(:person) { nil }
+
+    it 'does not run Interpretation' do
+      perform
+      expect(OpenAustralia::Interpretation::RecordMembershipsAndPositions).not_to have_received(:call)
+    end
+  end
+
+  context 'when ingest raises' do
+    before do
+      allow(OpenAustralia::IngestPerson).to receive(:call).and_raise(StandardError, 'boom')
+    end
+
+    it 're-raises and logs an ApiLog entry' do
+      expect { perform }.to raise_error(StandardError, 'boom').and change(ApiLog, :count).by(1)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

First half of Increment 3 (Scheduling & Automation) from `notes/ingest_federal_politicians_design.md`. Increments 1 (Ingest) and 2 (Interpretation) are both proven but only ever ran when a human triggered them from a console/rake task — nothing kept the pipeline current on its own.

- `OpenAustralia::IngestPersonJob` now runs `OpenAustralia::Interpretation::RecordMembershipsAndPositions` right after a successful `IngestPerson.call`, so every ingest is immediately interpreted into Membership/Position records instead of needing a separate rake-task pass.
- New `OpenAustralia::IngestCurrentPoliticiansJob` wraps the existing `OpenAustralia::IngestCurrentPoliticians` service so it's schedulable.
- `config/sidekiq.yml` schedules that job monthly, on the 5th at 00:00 AEST — chosen to avoid the 1st/2nd, where the ACNC, lobbyist, and AusTender backfill jobs already run.

Because `IngestPerson.call(person_id:)` always fetches a person's entire Term history regardless of why they were selected, and `RecordMembershipsAndPositions` is already idempotent and correctly closes previously-open periods when new data supersedes them, this single change covers two of Increment 3's needs at once: newly-elected politicians get discovered via the roster, and anyone still on the roster gets their Raw Terms and Memberships refreshed automatically.

## Deliberately not collapsing needs #1 and #2 into the DB-union job yet

The design doc raises collapsing "discover new" and "refresh/close current" into one job that unions the live roster with everyone our DB already considers current (open `Group.federal_parliament` membership), but flags that as something to validate before assuming. This PR takes the simpler first step — schedule the roster-only source — as a conscious choice, not an oversight: it's independently useful (ships need #1 and most of need #2 today) and keeps this PR small. The DB-side union to catch politicians who've dropped off the roster entirely (retired, lost their seat, disqualified) is a deliberate follow-up PR.

## Test plan

- [x] `bundle exec rspec spec/sidekiq/open_australia/ spec/services/open_australia/` — 62 examples, 0 failures
- [x] `bundle exec rubocop app/sidekiq/open_australia/ spec/sidekiq/open_australia/` — no offenses
- [ ] Verify the scheduled job appears correctly in Sidekiq Web (`/sidekiq`) after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
