### PR TITLE
Fix bundler-audit failure: bump json to 2.21.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,7 +199,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.21.1)
+    json (2.21.2)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)


### PR DESCRIPTION
## Summary
- `bundle exec bundler-audit --update` (matching CI's `bundler-audit` job) reported one vulnerability: CVE-2026-71847 / GHSA-9hj4-r449-hfvc in `json` 2.21.1 — `JSON::ResumableParser#partial_value` dereferences a freed input buffer and crashes on truncated duplicate-key streams.
- `json` is a transitive dependency (not pinned in the Gemfile), so this is a lockfile-only bump via `bundle update json` to 2.21.2, the fixed version.
- Re-ran `bundle exec bundler-audit` after the update — no vulnerabilities found.

## Test plan
- [x] `bundle exec bundler-audit --update` passes with no vulnerabilities
- [x] `bundle exec rspec spec/models` passes (66 examples, 0 failures)