### PR TITLE
Add maintenance_tasks gem for admin-run background tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,8 @@ gem "prettytodo"
 
 gem 'sidekiq-scheduler'
 
+gem 'maintenance_tasks'
+
 # For working with XLSX files
 gem "roo", "~> 3.0.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,6 +195,8 @@ GEM
     jbuilder (2.14.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
+    job-iteration (1.15.0)
+      activejob (>= 7.1)
     jquery-rails (4.6.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -224,6 +226,14 @@ GEM
       net-imap
       net-pop
       net-smtp
+    maintenance_tasks (2.17.0)
+      actionpack (>= 7.2)
+      activejob (>= 7.2)
+      activerecord (>= 7.2)
+      csv
+      job-iteration (>= 1.3.6)
+      railties (>= 7.2)
+      zeitwerk (>= 2.6.2)
     marcel (1.2.1)
     method_source (1.1.0)
     mini_mime (1.1.5)
@@ -529,6 +539,7 @@ DEPENDENCIES
   importmap-rails
   inertia_rails
   jbuilder
+  maintenance_tasks
   money-rails (~> 1.12)
   newrelic_rpm
   ostruct

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,13 @@
 require 'sidekiq/web' # require the web UI
 
 Rails.application.routes.draw do
-
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
 
   authenticate :admin_user do
     mount Flipper::UI.app(Flipper) => '/flipper'
     mount Sidekiq::Web => '/sidekiq'
+    mount MaintenanceTasks::Engine, at: '/maintenance_tasks'
   end
 
   mount Prettytodo::Engine => '/prettytodo' if Rails.env.development?

--- a/db/migrate/20260812031854_create_maintenance_tasks_runs.maintenance_tasks.rb
+++ b/db/migrate/20260812031854_create_maintenance_tasks_runs.maintenance_tasks.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20201211151756)
+class CreateMaintenanceTasksRuns < ActiveRecord::Migration[7.0]
+  def change
+    create_table(:maintenance_tasks_runs, id: primary_key_type) do |t|
+      t.string(:task_name, null: false)
+      t.datetime(:started_at)
+      t.datetime(:ended_at)
+      t.float(:time_running, default: 0.0, null: false)
+      t.integer(:tick_count, default: 0, null: false)
+      t.integer(:tick_total)
+      t.string(:job_id)
+      t.bigint(:cursor)
+      t.string(:status, default: :enqueued, null: false)
+      t.string(:error_class)
+      t.string(:error_message)
+      t.text(:backtrace)
+      t.timestamps
+      t.index(:task_name)
+      t.index([:task_name, :created_at], order: { created_at: :desc })
+    end
+  end
+
+  private
+
+  def primary_key_type
+    config = Rails.configuration.generators
+    setting = config.options[config.orm][:primary_key_type]
+    setting || :primary_key
+  end
+end

--- a/db/migrate/20260812031855_change_cursor_to_string.maintenance_tasks.rb
+++ b/db/migrate/20260812031855_change_cursor_to_string.maintenance_tasks.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20210219212931)
+class ChangeCursorToString < ActiveRecord::Migration[7.0]
+  # This migration will clear all existing data in the cursor column with MySQL.
+  # Ensure no Tasks are paused when this migration is deployed, or they will be resumed from the start.
+  # Running tasks are able to gracefully handle this change, even if interrupted.
+  def up
+    change_table(:maintenance_tasks_runs) do |t|
+      t.change(:cursor, :string)
+    end
+  end
+
+  def down
+    change_table(:maintenance_tasks_runs) do |t|
+      t.change(:cursor, :bigint)
+    end
+  end
+end

--- a/db/migrate/20260812031856_remove_index_on_task_name.maintenance_tasks.rb
+++ b/db/migrate/20260812031856_remove_index_on_task_name.maintenance_tasks.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20210225152418)
+class RemoveIndexOnTaskName < ActiveRecord::Migration[7.0]
+  def up
+    change_table(:maintenance_tasks_runs) do |t|
+      t.remove_index(:task_name)
+    end
+  end
+
+  def down
+    change_table(:maintenance_tasks_runs) do |t|
+      t.index(:task_name)
+    end
+  end
+end

--- a/db/migrate/20260812031857_add_arguments_to_maintenance_tasks_runs.maintenance_tasks.rb
+++ b/db/migrate/20260812031857_add_arguments_to_maintenance_tasks_runs.maintenance_tasks.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20210517131953)
+class AddArgumentsToMaintenanceTasksRuns < ActiveRecord::Migration[7.0]
+  def change
+    add_column(:maintenance_tasks_runs, :arguments, :text)
+  end
+end

--- a/db/migrate/20260812031858_add_lock_version_to_maintenance_tasks_runs.maintenance_tasks.rb
+++ b/db/migrate/20260812031858_add_lock_version_to_maintenance_tasks_runs.maintenance_tasks.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20211210152329)
+class AddLockVersionToMaintenanceTasksRuns < ActiveRecord::Migration[7.0]
+  def change
+    add_column(
+      :maintenance_tasks_runs,
+      :lock_version,
+      :integer,
+      default: 0,
+      null: false,
+    )
+  end
+end

--- a/db/migrate/20260812031859_change_runs_tick_columns_to_bigints.maintenance_tasks.rb
+++ b/db/migrate/20260812031859_change_runs_tick_columns_to_bigints.maintenance_tasks.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20220706101937)
+class ChangeRunsTickColumnsToBigints < ActiveRecord::Migration[7.0]
+  def up
+    change_table(:maintenance_tasks_runs, bulk: true) do |t|
+      t.change(:tick_count, :bigint)
+      t.change(:tick_total, :bigint)
+    end
+  end
+
+  def down
+    change_table(:maintenance_tasks_runs, bulk: true) do |t|
+      t.change(:tick_count, :integer)
+      t.change(:tick_total, :integer)
+    end
+  end
+end

--- a/db/migrate/20260812031860_add_index_on_task_name_and_status_to_runs.maintenance_tasks.rb
+++ b/db/migrate/20260812031860_add_index_on_task_name_and_status_to_runs.maintenance_tasks.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20220713131925)
+class AddIndexOnTaskNameAndStatusToRuns < ActiveRecord::Migration[7.0]
+  def change
+    remove_index(
+      :maintenance_tasks_runs,
+      column: [:task_name, :created_at],
+      order: { created_at: :desc },
+      name: :index_maintenance_tasks_runs_on_task_name_and_created_at,
+    )
+
+    add_index(
+      :maintenance_tasks_runs,
+      [:task_name, :status, :created_at],
+      name: :index_maintenance_tasks_runs,
+      order: { created_at: :desc },
+    )
+  end
+end

--- a/db/migrate/20260812031861_add_metadata_to_runs.maintenance_tasks.rb
+++ b/db/migrate/20260812031861_add_metadata_to_runs.maintenance_tasks.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20230622035229)
+class AddMetadataToRuns < ActiveRecord::Migration[7.0]
+  def change
+    add_column(:maintenance_tasks_runs, :metadata, :text)
+  end
+end

--- a/db/migrate/20260812031862_add_cursor_is_json_flag_to_runs.maintenance_tasks.rb
+++ b/db/migrate/20260812031862_add_cursor_is_json_flag_to_runs.maintenance_tasks.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20251128180556)
+class AddCursorIsJsonFlagToRuns < ActiveRecord::Migration[7.2]
+  def change
+    add_column(:maintenance_tasks_runs, :cursor_is_json, :boolean, default: false, null: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_28_122206) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_12_031862) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -133,6 +133,28 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_28_122206) do
     t.index ["giver_type", "giver_id"], name: "index_individual_transactions_on_giver"
     t.index ["taker_type", "taker_id"], name: "index_individual_transactions_on_taker"
     t.index ["transfer_id"], name: "index_individual_transactions_on_transfer_id"
+  end
+
+  create_table "maintenance_tasks_runs", force: :cascade do |t|
+    t.text "arguments"
+    t.text "backtrace"
+    t.datetime "created_at", null: false
+    t.string "cursor"
+    t.boolean "cursor_is_json", default: false, null: false
+    t.datetime "ended_at"
+    t.string "error_class"
+    t.string "error_message"
+    t.string "job_id"
+    t.integer "lock_version", default: 0, null: false
+    t.text "metadata"
+    t.datetime "started_at"
+    t.string "status", default: "enqueued", null: false
+    t.string "task_name", null: false
+    t.bigint "tick_count", default: 0, null: false
+    t.bigint "tick_total"
+    t.float "time_running", default: 0.0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["task_name", "status", "created_at"], name: "index_maintenance_tasks_runs", order: { created_at: :desc }
   end
 
   create_table "major_transaction_categories", force: :cascade do |t|


### PR DESCRIPTION
## Summary
- Add [Shopify's `maintenance_tasks`](https://github.com/Shopify/maintenance_tasks) gem for defining and running one-off/ad-hoc data tasks (backfills, cleanups, migrations of data) with a web UI for progress tracking, pause/resume, and error reporting — instead of hand-rolling rake tasks or throwaway Sidekiq jobs for these.
- Ran `bin/rails generate maintenance_tasks:install`, which added the `maintenance_tasks_runs` table via 9 migrations.
- Mounted the engine at `/maintenance_tasks`, inside the existing `authenticate :admin_user` block alongside Flipper UI and Sidekiq Web (moved from the generator's default unauthenticated mount point).

## Usage
Define tasks under `app/tasks/` with `bin/rails generate maintenance_tasks:task MyTask`, then run/monitor them at `/maintenance_tasks` when logged in as an admin user.

## Test plan
- [x] `bundle install` succeeds
- [x] Migrations run cleanly against dev DB
- [x] `MaintenanceTasks::Engine` loads via `bin/rails runner`
- [x] `bundle exec rubocop config/routes.rb` — no offenses
- [ ] Manually verify `/maintenance_tasks` is inaccessible when logged out and accessible as an admin user

🤖 Generated with [Claude Code](https://claude.com/claude-code)