### PR TITLE
Migrate councils-ii docs into the docs/ taxonomy

### DIFF
--- a/app/tasks/maintenance/backfill_nsw_council_election_results_task.rb
+++ b/app/tasks/maintenance/backfill_nsw_council_election_results_task.rb
@@ -1,8 +1,8 @@
 # Backfills the one prior NSW LG election cycle confirmed reachable in the current
 # pastvtr.elections.nsw.gov.au site structure (see
-# notes/2026-08-15-council-ingestion-production-readiness-goal-2.md for the live research behind
+# docs/plans/0009-council-ingestion-production-readiness-goal-2.md for the live research behind
 # that scope decision). Run from /maintenance_tasks -- order relative to the current-cycle import
-# no longer matters (see notes/2026-08-17-council-dates-deferred-to-interpretation.md).
+# no longer matters (see docs/adr/0006-council-membership-position-dates-deferred-to-interpretation.md).
 module Maintenance
   class BackfillNswCouncilElectionResultsTask < MaintenanceTasks::Task
     BACKFILL_ELECTION_ID = Councils::Nsw::Elections::ALL.first[:id]

--- a/app/tasks/maintenance/backfill_vic_council_election_results_task.rb
+++ b/app/tasks/maintenance/backfill_vic_council_election_results_task.rb
@@ -1,8 +1,8 @@
 # Backfills the one prior VIC council election cycle confirmed reachable in the current
 # vec.vic.gov.au site structure (see
-# notes/2026-08-15-council-ingestion-production-readiness-goal-2.md for the live research behind
+# docs/plans/0009-council-ingestion-production-readiness-goal-2.md for the live research behind
 # that scope decision). Run from /maintenance_tasks -- order relative to the current-cycle import
-# no longer matters (see notes/2026-08-17-council-dates-deferred-to-interpretation.md).
+# no longer matters (see docs/adr/0006-council-membership-position-dates-deferred-to-interpretation.md).
 module Maintenance
   class BackfillVicCouncilElectionResultsTask < MaintenanceTasks::Task
     BACKFILL_ELECTION_YEAR = Councils::Vic::Elections::ALL.first[:year]

--- a/docs/adr/0006-council-membership-position-dates-deferred-to-interpretation.md
+++ b/docs/adr/0006-council-membership-position-dates-deferred-to-interpretation.md
@@ -1,8 +1,10 @@
 # Council Membership/Position dates deferred to a future interpretation pass
 
+**Status:** Accepted
+
 ## Context
 
-A staging spot-check (see `notes/2026-08-15-council-ingestion-production-readiness-goal-2.md`'s
+A staging spot-check (see `docs/plans/0009-council-ingestion-production-readiness-goal-2.md`'s
 incident) found that even correctly-functioning backfill data "didn't feel right": most NSW
 councillors ended up with both a `start_date` *and* an `end_date` on their Membership, and the
 associated `Councillor` Position had neither (a separate, smaller bug -- see below). Looking past
@@ -39,7 +41,7 @@ duplicate entries.
 Each observation: `state`, `council_name`, `council_slug`, `cycle` (NSW: `LG2401`-style election
 id; VIC: year), `declared_date`, `party` (NSW only), `source_url`. `declared_date` still applies
 VIC's existing election_date override for non-latest cycles (VEC's archived "Last updated" stamp
-is unreliable -- see `notes/2026-08-15-...`) -- that override was never about Membership dates
+is unreliable -- see `docs/plans/0009-council-ingestion-production-readiness-goal-2.md`) -- that override was never about Membership dates
 specifically, it's about recording the best available date in the raw data at all.
 
 ## What this removes
@@ -58,11 +60,12 @@ specifically, it's about recording the best available date in the raw data at al
 ## Consequence: run order no longer matters
 
 The whole "current cycle must be imported before backfill" constraint from
-`notes/2026-08-15-...`/`notes/council-ingestion-run-order.md` existed only because
-`backfill_end_date` needed to check for an already-open Membership to decide continuity. With no
-dates and no close-out logic, `Group::RecordRow`'s dedup (matching on *any* open Membership,
-regardless of when it was created) makes the backfill and current-cycle imports fully
-order-independent. `notes/council-ingestion-run-order.md` has been updated accordingly.
+`docs/plans/0009-council-ingestion-production-readiness-goal-2.md`/`docs/runbooks/council-ingestion-run-order.md`
+existed only because `backfill_end_date` needed to check for an already-open Membership to decide
+continuity. With no dates and no close-out logic, `Group::RecordRow`'s dedup (matching on *any*
+open Membership, regardless of when it was created) makes the backfill and current-cycle imports
+fully order-independent. `docs/runbooks/council-ingestion-run-order.md` has been updated
+accordingly.
 
 ## Also fixed in passing
 
@@ -76,7 +79,7 @@ mechanism is generically correct).
 ## Deferred: the interpretation pass
 
 Not built yet. Once enough historical depth exists (see the "how far back" discussion in
-`notes/2026-08-15-...`) to derive real tenure dates with confidence, a
+`docs/plans/0009-council-ingestion-production-readiness-goal-2.md`) to derive real tenure dates with confidence, a
 `Councils::Interpretation::RecordMembershipsAndPositions`-style service (mirroring OpenAustralia's)
 would read `Person#council_election_data` and populate real `start_date`/`end_date` values. Until
 then, council Membership/Position dates are simply absent, not approximated.

--- a/docs/plans/0002-local-council-councillor-ingestion.md
+++ b/docs/plans/0002-local-council-councillor-ingestion.md
@@ -1,6 +1,6 @@
 # Local Council Councillor Ingestion (NSW + VIC Electoral Commissions)
 
-**Status:** Proposed
+**Status:** Implemented
 
 ## Context
 

--- a/docs/plans/0007-council-ingestion-production-readiness-goal-1.md
+++ b/docs/plans/0007-council-ingestion-production-readiness-goal-1.md
@@ -1,8 +1,10 @@
 # Council Ingestion — Production Readiness, Goal 1 (Full ingest, current cycle)
 
+**Status:** Implemented
+
 ## Context
 
-`context/2026-07-28-local-council-councillor-ingestion.md` covers what already shipped: working NSW + VIC per-council import jobs, fanned out from an index-discovery job, using `rand(1..60).seconds` jitter designed for a small pilot run. Before running this for real across every council in both states, three gaps needed resolving. This doc covers the first: spacing, trigger mechanism, and success criteria for the initial full-scale run. (Goals 2 and 3 — historical backfill and scheduling — are separate, later docs.)
+`docs/plans/0002-local-council-councillor-ingestion.md` covers what already shipped: working NSW + VIC per-council import jobs, fanned out from an index-discovery job, using `rand(1..60).seconds` jitter designed for a small pilot run. Before running this for real across every council in both states, three gaps needed resolving. This doc covers the first: spacing, trigger mechanism, and success criteria for the initial full-scale run. (Goals 2 and 3 — historical backfill and scheduling — are separate, later docs.)
 
 ## Decisions
 
@@ -24,6 +26,6 @@ After triggering both jobs and letting them finish (~3-4 hours):
 - Undeclared contests: any council/ward not yet declared at run time is expected to simply be absent from this run's results (by design — see the governing doc's "wait for every contest to declare" note for NSW). Confirm this reads as "no data yet," not as an error, for any such council.
 - Browse `/admin/groups` filtered to "Australian Local Councils" and `/admin/memberships` for a couple of pilot councils to confirm the data reads sensibly through existing admin screens.
 
-## Status
+## Rollout status
 
 Code changes complete and spec-covered (`spec/sidekiq/councils/{nsw,vic}/ingest_election_results_job_spec.rb` — existing assertions on `kind_of(ActiveSupport::Duration)` needed no changes). The full-scale run itself has not been triggered yet — held pending a deliberate go-ahead, since it's a production-writing, real-external-site-hitting action.

--- a/docs/plans/0008-council-ingestion-production-readiness-goal-3.md
+++ b/docs/plans/0008-council-ingestion-production-readiness-goal-3.md
@@ -1,8 +1,10 @@
 # Council Ingestion — Production Readiness, Goal 3 (Scheduled job for fresh results)
 
+**Status:** Implemented
+
 ## Context
 
-Follows `context/2026-08-11-council-ingestion-production-readiness-goal-1.md`. Goal 3 wires `Councils::{Nsw,Vic}::IngestElectionResultsJob` into `sidekiq-scheduler` so re-runs happen without manual triggering, per the recommended Goal 1 → Goal 3 → Goal 2 order in the original brief (Goal 3 needed no changes to the underlying import logic, just scheduling — Goal 1's fan-out/spacing work already proved the pipeline at full scale).
+Follows `docs/plans/0007-council-ingestion-production-readiness-goal-1.md`. Goal 3 wires `Councils::{Nsw,Vic}::IngestElectionResultsJob` into `sidekiq-scheduler` so re-runs happen without manual triggering, per the recommended Goal 1 → Goal 3 → Goal 2 order in the original brief (Goal 3 needed no changes to the underlying import logic, just scheduling — Goal 1's fan-out/spacing work already proved the pipeline at full scale).
 
 ## Decisions
 
@@ -18,8 +20,8 @@ Both jobs (and their per-council import jobs) were also moved onto the existing 
 - Near-term: catches any wards/councils that hadn't declared yet on the initial Goal 1 full run (NSW's `close_departed_members` guard explicitly waits for every contest to declare, so late declarations need a follow-up run to get picked up and closed out correctly).
 - Long-term: a cheap, idempotent, indefinite backstop/re-validation once 2024 results are fully settled — low value but harmless.
 
-Real 2028 coverage requires the election-id/year to become parameterized (or the constants manually bumped) before then — that's Goal 2's territory (`context/2026-07-28-local-council-councillor-ingestion.md`'s backfill design), not solved by this scheduler entry. Flagging this explicitly now so it isn't silently assumed solved.
+Real 2028 coverage requires the election-id/year to become parameterized (or the constants manually bumped) before then — that's Goal 2's territory (`docs/plans/0009-council-ingestion-production-readiness-goal-2.md`'s backfill design), not solved by this scheduler entry. Flagging this explicitly now so it isn't silently assumed solved.
 
-## Status
+## Rollout status
 
 Code changes complete: `queue: :low` added to all four job classes, two monthly cron entries added to `config/sidekiq.yml`. No spec changes needed (scheduler config isn't exercised by the job specs; `sidekiq_options` queue is not asserted anywhere in existing specs).

--- a/docs/plans/0009-council-ingestion-production-readiness-goal-2.md
+++ b/docs/plans/0009-council-ingestion-production-readiness-goal-2.md
@@ -1,8 +1,10 @@
 # Council Ingestion — Production Readiness, Goal 2 (Backfill older election cycles)
 
+**Status:** Implemented
+
 ## Context
 
-Follows Goal 1 (`context/2026-08-11-...`) and Goal 3 (`context/2026-08-12-...`). This removes the
+Follows Goal 1 (`docs/plans/0007-council-ingestion-production-readiness-goal-1.md`) and Goal 3 (`docs/plans/0008-council-ingestion-production-readiness-goal-3.md`). This removes the
 hardcoded `ELECTION_ID`/`ELECTION_YEAR` constants from `Councils::{Nsw,Vic}::ImportCouncilResultRowJob`
 and `Councils::{Nsw,Vic}::IngestElectionResultsJob`, parameterizing them to accept an election
 cycle, and adds a backfill of the one prior cycle confirmed reachable in each state.

--- a/docs/runbooks/council-ingestion-run-order.md
+++ b/docs/runbooks/council-ingestion-run-order.md
@@ -2,7 +2,7 @@
 
 How to (re-)populate NSW/VIC council election data from scratch (e.g. after a DB restore).
 
-**Order no longer matters for correctness.** As of `notes/2026-08-17-council-dates-deferred-to-interpretation.md`,
+**Order no longer matters for correctness.** As of `docs/adr/0006-council-membership-position-dates-deferred-to-interpretation.md`,
 `Councils::{Nsw,Vic}::ImportCouncilResultRowJob` records no `start_date`/`end_date` at all on
 Membership/Position -- it just ensures the (undated) Membership exists, and appends a raw dated
 observation to `Person#council_election_data`. `Group::RecordRow`'s dedup (matching on an *open*
@@ -49,4 +49,4 @@ zero-record skips:
 `ingest_vic_council_election_results_job` cron entries re-run the *current* cycle monthly,
 idempotently -- no need to re-run anything manually going forward, except a future backfill if we
 ever extend coverage further back (see the "known limitation" section of
-`notes/2026-08-15-council-ingestion-production-readiness-goal-2.md`).
+`docs/plans/0009-council-ingestion-production-readiness-goal-2.md`).


### PR DESCRIPTION
## Summary
- The `councils-ii` branch (PR #245) predated the `docs/` taxonomy landing on `main`, so its 5 design/decision docs stayed in `notes/` with dated filenames instead of being classified into `docs/adr/`, `docs/plans/`, or `docs/runbooks/`.
- Moves each doc to the right folder per `CODING_STANDARDS.md`'s `## Docs` section, adds `Status:` lines, and fixes the resulting dead cross-references — including two Ruby source comments (`app/tasks/maintenance/backfill_{nsw,vic}_council_election_results_task.rb`) that pointed at the old `notes/` paths.
- Bumps `docs/plans/0002-local-council-councillor-ingestion.md`'s status from `Proposed` to `Implemented`, since the migrated docs confirm that work shipped.

## Test plan
- [x] `grep` sweep confirms no remaining references to the old `notes/` paths anywhere in `.rb`/`.md`/`.erb` files
- [x] File moves only (`git mv`) plus link/status text edits — no behavioural code changes, so no test run needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)