### PR TITLE
Fix Rails/FilePath offense in AuLobbyists::FileDownloader

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -435,14 +435,6 @@ Rails/Date:
   Exclude:
     - 'app/sidekiq/backfill_contracts_master_job.rb'
 
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: slashes, arguments
-Rails/FilePath:
-  Exclude:
-    - 'app/services/au_lobbyists/file_downloader.rb'
-
 # Offense count: 6
 Rails/I18nLocaleTexts:
   Exclude:

--- a/app/services/au_lobbyists/file_downloader.rb
+++ b/app/services/au_lobbyists/file_downloader.rb
@@ -32,7 +32,7 @@ class AuLobbyists::FileDownloader
     # Verify it worked
     if response.success?
       # The API returns raw CSV content in the body
-      path = Rails.root.join('tmp', 'lobbyists.xlsx')
+      path = Rails.root.join('tmp/lobbyists.xlsx')
       # write as binary so Ruby doesn't try to transcode
       File.open(path, 'wb') do |f|
         f.write(response.body)


### PR DESCRIPTION
## Summary
- Resolve one entry from `.rubocop_todo.yml`: `Rails/FilePath` in `app/services/au_lobbyists/file_downloader.rb`
- Use `Rails.root.join('tmp/lobbyists.xlsx')` instead of `Rails.root.join('tmp', 'lobbyists.xlsx')`

## Test plan
- [x] `bundle exec rubocop app/services/au_lobbyists/file_downloader.rb` — no offenses