### PR TITLE
Increment 3b: union DB-current politicians into the monthly re-ingest

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -30,6 +30,8 @@ class Membership < ApplicationRecord
 
   scope :person_in_lobbyists, -> { where(member_type: 'Person', group_id: Group.lobbyists_tag.id) }
 
+  scope :person_currently_in_federal_parliament, -> { where(member_type: 'Person', group_id: Group.federal_parliament.id, end_date: nil) }
+
   def self.ransackable_scopes(_auth_object = nil)
     [:by_ids]
   end

--- a/app/services/open_australia/ingest_current_politicians.rb
+++ b/app/services/open_australia/ingest_current_politicians.rb
@@ -8,7 +8,15 @@ class OpenAustralia::IngestCurrentPoliticians
   private
 
   def person_ids
+    (roster_person_ids + db_current_person_ids).uniq
+  end
+
+  def roster_person_ids
     (api_client.get_representatives + api_client.get_senators).map { |term| term['person_id'] }.uniq
+  end
+
+  def db_current_person_ids
+    Person.where(id: Membership.person_currently_in_federal_parliament.select(:member_id)).filter_map(&:open_australia_id)
   end
 
   def api_client

--- a/docs/plans/0004-ingest-federal-politicians-design.md
+++ b/docs/plans/0004-ingest-federal-politicians-design.md
@@ -65,14 +65,14 @@ Confirmed with the project owner: this ships as two PRs, and the two needs colla
 - Scheduled monthly in `config/sidekiq.yml`, cron `'0 14 4 * *'` — lands at 00:00 AEST on the 5th (cron day is 4, not 5, because hour 14 UTC rolls into the next AEST day per the file's own conversion table; this is commented inline both in the cron entry and in `IngestPersonJob`). Day 5 was chosen to avoid the 1st/2nd, where ACNC/lobbyist/AusTender-backfill jobs already run.
 - This alone covers need #1 (new politicians via the roster) and *most* of need #2 (anyone still on the roster gets refreshed) — but not the case where someone drops off the roster entirely. That's 3b.
 
-### Increment 3b — not started
+### Increment 3b — done
 
-Add the DB-side half of need #2: politicians who've left the roster entirely (retirement, lost seat, disqualification) and so are never re-ingested by 3a's roster-only job, even though our DB still shows them as current.
+Added the DB-side half of need #2: politicians who've left the roster entirely (retirement, lost seat, disqualification) and so were never re-ingested by 3a's roster-only job, even though our DB still shows them as current.
 
-- **"Politicians our database considers current" already has a precise definition, no new schema needed**: people with an open (`end_date: nil`) `Membership` in `Group.federal_parliament` (id 877).
-- **Extend the existing scheduled job, don't add a second one.** Union the OpenAustralia live roster's `person_id`s (already fetched by `OpenAustralia::IngestCurrentPoliticians`) with the `person_id`s of everyone our DB currently considers a sitting politician (the query above), dedupe, enqueue one `IngestPersonJob` per person. The two sources diverge exactly where it matters — someone who dropped off the live roster is only in the DB-side set (the "they left" case), a fresh by-election winner is only in the roster-side set (the "new politician" case) — so the union covers both needs with the one job 3a already scheduled monthly.
+- New `Membership.person_currently_in_federal_parliament` scope — `Person` members with an open (`end_date: nil`) `Membership` in `Group.federal_parliament` (id 877), mirroring the existing `person_in_lobbyists`/`person_in_charity` scope pattern.
+- `OpenAustralia::IngestCurrentPoliticians#person_ids` now unions `roster_person_ids` (unchanged, from the live API) with `db_current_person_ids` (`Person`s matching the new scope, mapped to `open_australia_id`, dropping anyone without one), deduped, before the existing per-id `IngestPersonJob.perform_async` fan-out — no change to the fan-out itself, each id still gets its own async job.
 - No new Ingest or Interpretation logic needed — `IngestPersonJob` (as of 3a) already does ingest-then-interpret for whatever `person_id` it's given, regardless of which side of the union surfaced it.
-- Likely lands as a change to `OpenAustralia::IngestCurrentPoliticians` (or the job wrapping it) to also pull the DB-side `person_id` set before enqueuing, plus a spec covering the "dropped off the roster" case specifically.
+- Covered by spec: dropped-off-roster person still enqueued, current-on-both-sides person enqueued only once, and a person whose Membership has since closed (`end_date` set) is not enqueued via the DB side.
 
 ---
 

--- a/spec/services/open_australia/ingest_current_politicians_spec.rb
+++ b/spec/services/open_australia/ingest_current_politicians_spec.rb
@@ -7,11 +7,13 @@ RSpec.describe OpenAustralia::IngestCurrentPoliticians, type: :service do
   let(:representatives) { JSON.parse(File.read(fixture_dir.join('get_representatives.json'))) }
   let(:senators) { JSON.parse(File.read(fixture_dir.join('get_senators.json'))) }
   let(:api_client) { instance_double(OpenAustralia::ApiClient) }
+  let(:parliament_group) { create(:group, name: 'australian federal parliament') }
 
   before do
     allow(OpenAustralia::ApiClient).to receive(:new).and_return(api_client)
     allow(api_client).to receive_messages(get_representatives: representatives, get_senators: senators)
     allow(OpenAustralia::IngestPersonJob).to receive(:perform_async).and_return(true)
+    allow(Group).to receive(:federal_parliament).and_return(parliament_group)
   end
 
   it 'enqueues one IngestPersonJob per representative' do
@@ -37,6 +39,50 @@ RSpec.describe OpenAustralia::IngestCurrentPoliticians, type: :service do
     it 'enqueues only one job for that person_id, not two' do
       call
       expect(OpenAustralia::IngestPersonJob).to have_received(:perform_async).with('10007').once
+    end
+  end
+
+  context 'when the database has a person we still consider current, but who has dropped off the live roster' do
+    before do
+      person = create(:person)
+      person.open_australia_id = '99999'
+      create(:membership, member: person, group: parliament_group, end_date: nil)
+    end
+
+    it 'still enqueues a job for that person_id' do
+      call
+      expect(OpenAustralia::IngestPersonJob).to have_received(:perform_async).with('99999')
+    end
+
+    it 'enqueues exactly 5 jobs (4 from the roster plus the dropped-off person)' do
+      call
+      expect(OpenAustralia::IngestPersonJob).to have_received(:perform_async).exactly(5).times
+    end
+  end
+
+  context 'when a database person considered current is also still on the live roster' do
+    before do
+      person = create(:person)
+      person.open_australia_id = '10007'
+      create(:membership, member: person, group: parliament_group, end_date: nil)
+    end
+
+    it 'enqueues only one job for that person_id, not two' do
+      call
+      expect(OpenAustralia::IngestPersonJob).to have_received(:perform_async).with('10007').once
+    end
+  end
+
+  context 'when a database person has left the parliament group (end_date set)' do
+    before do
+      person = create(:person)
+      person.open_australia_id = '55555'
+      create(:membership, member: person, group: parliament_group, end_date: 1.year.ago)
+    end
+
+    it 'does not enqueue a job for that person_id' do
+      call
+      expect(OpenAustralia::IngestPersonJob).not_to have_received(:perform_async).with('55555')
     end
   end
 end


### PR DESCRIPTION
## Summary
- Increment 3b of the OpenAustralia federal politician pipeline (see `docs/plans/0004-ingest-federal-politicians-design.md`). 3a's monthly job only re-fetches whoever is still on the live roster, so a politician who drops off entirely (retirement, lost seat, disqualification) was never re-ingested and their Parliament Membership never closed.
- `OpenAustralia::IngestCurrentPoliticians#person_ids` now unions the live-roster ids with the ids of everyone our DB still considers a sitting federal politician (new `Membership.person_currently_in_federal_parliament` scope → `open_australia_id`), deduped, before the existing per-id `IngestPersonJob` fan-out.
- No schema change, no new job — rides on 3a's existing monthly `IngestCurrentPoliticiansJob`.

## Test plan
- [x] `bundle exec rspec spec/services/open_australia/ingest_current_politicians_spec.rb` — new cases: dropped-off-roster person still enqueued, current-on-both-sides enqueued once, closed-membership person not enqueued via DB side
- [x] `bundle exec rspec spec/services/open_australia spec/sidekiq/open_australia` — 66 examples, 0 failures
- [x] `bundle exec rubocop` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)