### PR TITLE
Remove stale TODO about one-directional group memberships

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -70,8 +70,6 @@ class Group < ApplicationRecord
 
   has_many :trading_names, as: :owner, dependent: :destroy
 
-  # TODO: memberships are only working on one direction, need to fix this
-  # affiliated groups are not being followed from child to parent to other child
   has_many :memberships, dependent: :destroy
   has_many :memberships_as_member, as: :member, class_name: 'Membership', dependent: :destroy
   has_many :people, through: :memberships, source: :member, source_type: 'Person'


### PR DESCRIPTION
## Summary
- The TODO in `app/models/group.rb` claimed group memberships only traversed one direction (child → parent), preventing the graph traversal from following affiliated groups both ways.
- That was true when the comment was written (May 2024), but `parent_groups`/`affiliated_groups` were added in Oct 2024, making `Group#nodes` (used by `BuildQueue` traversal and `Cache::NodeCountJob`) already traverse both directions.
- Comment is stale and misleading — removed it, no behavior change.

## Test plan
- [x] Confirmed `Group#nodes` → `affiliated_groups` → `parent_groups + groups` covers both membership directions
- [x] Confirmed `BuildQueue` and `Cache::NodeCountJob` traverse via `.nodes`
- No functional change, so no new tests needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)