### PR TITLE
Fix Style/BlockComments offense in spec_helper.rb

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -511,12 +511,6 @@ Rails/WhereMissing:
     - 'app/sidekiq/ingest_twenty_charities_missing_people_job.rb'
 
 # Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Style/BlockComments:
-  Exclude:
-    - 'spec/spec_helper.rb'
-
-# Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: MinBranchesCount.
 Style/CaseLikeIf:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,51 +44,49 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  # # This allows you to limit a spec run to individual examples or groups
+  # # you care about by tagging them with `:focus` metadata. When nothing
+  # # is tagged with `:focus`, all examples get run. RSpec also provides
+  # # aliases for `it`, `describe`, and `context` that include `:focus`
+  # # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  # config.filter_run_when_matching :focus
+  #
+  # # Allows RSpec to persist some state between runs in order to support
+  # # the `--only-failures` and `--next-failure` CLI options. We recommend
+  # # you configure your source control system to ignore this file.
+  # config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  # # Limits the available syntax to the non-monkey patched syntax that is
+  # # recommended. For more details, see:
+  # # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
+  # config.disable_monkey_patching!
+  #
+  # # Many RSpec users commonly either run the entire suite or an individual
+  # # file, and it's useful to allow more verbose output when running an
+  # # individual spec file.
+  # if config.files_to_run.one?
+  #   # Use the documentation formatter for detailed output,
+  #   # unless a formatter has already been configured
+  #   # (e.g. via a command-line flag).
+  #   config.default_formatter = "doc"
+  # end
+  #
+  # # Print the 10 slowest examples and example groups at the
+  # # end of the spec run, to help surface which specs are running
+  # # particularly slow.
+  # config.profile_examples = 10
+  #
+  # # Run specs in random order to surface order dependencies. If you find an
+  # # order dependency and want to debug it, you can fix the order by providing
+  # # the seed, which is printed after each run.
+  # #     --seed 1234
+  # config.order = :random
+  #
+  # # Seed global randomization in this process using the `--seed` CLI option.
+  # # Setting this allows you to use `--seed` to deterministically reproduce
+  # # test failures related to randomization by passing the same `--seed` value
+  # # as the one that triggered the failure.
+  # Kernel.srand config.seed
 end


### PR DESCRIPTION
## Summary
- Converts the `=begin`/`=end` block of default RSpec boilerplate in `spec/spec_helper.rb` to `#`-prefixed line comments
- Removes the now-resolved `Style/BlockComments` exclusion from `.rubocop_todo.yml`

## Test plan
- [x] `bundle exec rubocop` — 265 files inspected, no offenses detected