### PR TITLE
Increment 4: historical backfill of federal politicians (OpenAustralia id sweep)

### DIFF
--- a/app/services/open_australia/api_client.rb
+++ b/app/services/open_australia/api_client.rb
@@ -31,7 +31,14 @@ class OpenAustralia::ApiClient
     raise OpenAustraliaRateLimitError, "#{response.status}: #{response.body}" if response.status == 429
     raise OpenAustraliaApiError, "#{response.status}: #{response.body}" unless response.success?
 
-    JSON.parse(response.body)
+    parsed = JSON.parse(response.body)
+    # A 200 response can still carry an error payload (e.g. a missing/invalid API key) as a
+    # JSON object instead of the expected Array -- surface that clearly here rather than letting
+    # every caller hit a confusing NoMethodError further downstream when it tries to treat the
+    # object as a list of terms.
+    raise OpenAustraliaApiError, "#{action}: #{parsed['error']}" if parsed.is_a?(Hash) && parsed['error']
+
+    parsed
   end
 
   def connection

--- a/app/services/open_australia/api_client.rb
+++ b/app/services/open_australia/api_client.rb
@@ -1,4 +1,5 @@
 class OpenAustraliaApiError < StandardError; end
+class OpenAustraliaRateLimitError < OpenAustraliaApiError; end
 
 class OpenAustralia::ApiClient
   BASE_URL = 'https://www.openaustralia.org.au/api/'.freeze
@@ -27,6 +28,7 @@ class OpenAustralia::ApiClient
 
   def get(action, params = {})
     response = connection.get(action, params.merge(key: api_key, output: 'js'))
+    raise OpenAustraliaRateLimitError, "#{response.status}: #{response.body}" if response.status == 429
     raise OpenAustraliaApiError, "#{response.status}: #{response.body}" unless response.success?
 
     JSON.parse(response.body)

--- a/app/services/open_australia/ingest_person.rb
+++ b/app/services/open_australia/ingest_person.rb
@@ -1,4 +1,11 @@
 class OpenAustralia::IngestPerson
+  include OpenAustralia::RawTermDates
+
+  # ADR 0004: ingestion is scoped to the last 50 years. Nothing else in this service enforces
+  # that window, so a person whose terms are all older than this is treated the same as a person
+  # with no terms at all.
+  WINDOW_YEARS = 50
+
   def self.call(person_id:) = new(person_id:).call
 
   def initialize(person_id:)
@@ -6,7 +13,7 @@ class OpenAustralia::IngestPerson
   end
 
   def call
-    return nil if terms.empty?
+    return nil if terms.empty? || outside_window?
 
     People::RecordPerson
       .call(terms.last['full_name'], open_australia_id: person_id)
@@ -21,6 +28,20 @@ class OpenAustralia::IngestPerson
 
   def terms
     @terms ||= (representative_terms + senator_terms).sort_by { |term| term['entered_house'] }
+  end
+
+  # A term counts as within the window if it's still ongoing (parse_date treats the "9999-12-31"
+  # sentinel as nil) or if it entered or left within the last WINDOW_YEARS.
+  def outside_window?
+    terms.none? { |term| term_within_window?(term) }
+  end
+
+  def term_within_window?(term)
+    left_date = parse_date(term['left_house'])
+    return true if left_date.nil? # still ongoing
+
+    entered_date = parse_date(term['entered_house'])
+    left_date >= WINDOW_YEARS.years.ago || entered_date&.>=(WINDOW_YEARS.years.ago)
   end
 
   def representative_terms

--- a/app/services/open_australia/interpretation/extract_periods.rb
+++ b/app/services/open_australia/interpretation/extract_periods.rb
@@ -1,5 +1,5 @@
 class OpenAustralia::Interpretation::ExtractPeriods
-  include OpenAustralia::Interpretation::RawTermDates
+  include OpenAustralia::RawTermDates
   private :contiguous?, :parse_date
 
   ParliamentPeriod = Struct.new(:house, :position, :constituency, :start_date, :end_date, keyword_init: true)

--- a/app/services/open_australia/interpretation/resolve_party_affiliations.rb
+++ b/app/services/open_australia/interpretation/resolve_party_affiliations.rb
@@ -1,5 +1,5 @@
 class OpenAustralia::Interpretation::ResolvePartyAffiliations
-  include OpenAustralia::Interpretation::RawTermDates
+  include OpenAustralia::RawTermDates
   private :contiguous?, :parse_date
 
   # Checked in order, first match wins. Liberal National Party is checked ahead of the bare

--- a/app/services/open_australia/max_known_person_id.rb
+++ b/app/services/open_australia/max_known_person_id.rb
@@ -1,0 +1,17 @@
+class OpenAustralia::MaxKnownPersonId
+  def self.call = new.call
+
+  def call
+    roster_person_ids.map(&:to_i).max
+  end
+
+  private
+
+  def roster_person_ids
+    (api_client.get_representatives + api_client.get_senators).map { |term| term['person_id'] }
+  end
+
+  def api_client
+    @api_client ||= OpenAustralia::ApiClient.new
+  end
+end

--- a/app/services/open_australia/raw_term_dates.rb
+++ b/app/services/open_australia/raw_term_dates.rb
@@ -1,4 +1,4 @@
-module OpenAustralia::Interpretation::RawTermDates
+module OpenAustralia::RawTermDates
   def contiguous?(prev, curr)
     prev['left_house'] == curr['entered_house']
   end

--- a/app/sidekiq/open_australia/ingest_person_job.rb
+++ b/app/sidekiq/open_australia/ingest_person_job.rb
@@ -1,5 +1,6 @@
 class OpenAustralia::IngestPersonJob
   include Sidekiq::Job
+  sidekiq_options lock: :until_executed, on_conflict: :log
 
   def perform(person_id)
     person = OpenAustralia::IngestPerson.call(person_id:)

--- a/app/tasks/maintenance/backfill_historical_politicians_task.rb
+++ b/app/tasks/maintenance/backfill_historical_politicians_task.rb
@@ -1,0 +1,35 @@
+# Sweeps every OpenAustralia person_id from 1 up to the highest id currently seen on the live
+# roster, so that people who served at any point in the last 50 years (ADR 0004) get ingested,
+# not just currently-serving politicians (see docs/plans/0004-ingest-federal-politicians-design.md,
+# Increment 4). OpenAustralia::IngestPerson already fetches a person's full Term history
+# regardless of how the id was discovered, and already no-ops for ids with no data or with no
+# terms inside the 50-year window -- this task is purely the id-sweep driver.
+module Maintenance
+  class BackfillHistoricalPoliticiansTask < MaintenanceTasks::Task
+    SPACING = 2.seconds
+
+    def collection
+      (1..self.class.max_person_id).to_a
+    end
+    delegate :count, to: :collection
+
+    # Enqueues rather than ingesting inline, so a single id's failure retries and dead-letters via
+    # Sidekiq's own machinery instead of halting the task run. A flat per-item delay (not one
+    # accumulated off this id's position in the range) is deliberate -- this task can be paused
+    # and resumed from the maintenance_tasks UI, and an accumulating delay computed relative to
+    # run start would over- or under-delay whatever resumes after a pause.
+    def process(person_id)
+      OpenAustralia::IngestPersonJob.perform_in(SPACING, person_id)
+    end
+
+    # Memoized at the class level, not the instance level: job-iteration calls #collection fresh
+    # on every batch of this run (each batch gets a new Task instance), so an instance-level memo
+    # would hit the live roster API on every batch, and a roster change mid-run would change
+    # #collection's size between batches -- which can break cursor-based resumption. A class-level
+    # memo computes this once per Sidekiq process lifetime; a redeploy mid-run just picks up a
+    # fresh number, which is an accepted tradeoff (see the design doc).
+    def self.max_person_id
+      @max_person_id ||= OpenAustralia::MaxKnownPersonId.call
+    end
+  end
+end

--- a/docs/plans/0004-ingest-federal-politicians-design.md
+++ b/docs/plans/0004-ingest-federal-politicians-design.md
@@ -76,18 +76,70 @@ Added the DB-side half of need #2: politicians who've left the roster entirely (
 
 ---
 
-## Increment 4 — Historical backfill (after Interpretation is proven)
+## Increment 4 — Historical backfill (design finalized 2026-08-20, not yet implemented)
 
 Goal: ingest *all* federal politicians within the 50-year window (ADR 0004), not just current ones.
 
-This needs its own design pass — it's a genuinely different problem from Increment 1, not just "run the same thing on a bigger list":
+**Rejected approach:** sampling roster snapshots at each election date (`getRepresentatives`/`getSenators` with a `date` param). Two problems: the project owner considers this API path unreliable in practice, and even in principle it has a coverage gap — a by-election winner who both entered and left between two general elections would never appear in any snapshot.
 
-- There's no single "everyone who's ever served" roster endpoint. `getRepresentatives`/`getSenators` take an optional `date` param and return the roster *as it stood on that date* — historical discovery means querying across many historical dates and deduplicating `person_id`s.
-- A naive approach (one query per election date) has a real gap: someone who won a by-election and then lost their seat (or died, or resigned) entirely between two general elections would never appear in any election-day snapshot. Sampling more densely (e.g. every few months) reduces but may not eliminate this risk — worth explicitly deciding what risk is acceptable rather than discovering it by omission.
-- Whatever discovery strategy is chosen, it only needs to produce a list of `person_id`s — `OpenAustralia::IngestPerson` (already built) handles the rest unchanged, since it always fetches a person's *entire* Term history regardless of which date surfaced them.
-- Volume is much larger than 226 — worth revisiting whether throttling is still unnecessary (Increment 1 deliberately skipped it for a one-off ~226-person run; that reasoning doesn't automatically extend to a much larger historical run).
+**Chosen approach: brute-force sweep of `person_id`.** `OpenAustralia::IngestPerson` already fetches a person's *entire* Term history regardless of how the `person_id` was discovered, and already no-ops (`nil`) when an id has no terms. So instead of discovering ids by date, sweep every `person_id` from 1 up to the highest id currently seen on the live roster, and let the existing ingest/interpret pipeline do the rest unchanged.
 
-Run `/grill-with-docs` for this increment specifically before implementing — the discovery-strategy question above needs a real decision, not an assumption.
+This design went through a `grill-me` pass after the first draft; several of the sub-steps below reflect real bugs/gaps that pass surfaced (noted inline), not just the original sketch.
+
+### Sub-steps
+
+1. **Enforce ADR 0004's 50-year window inside `OpenAustralia::IngestPerson`.** Nothing in the codebase enforces this today — Increment 1 achieved it only as a side effect of ingesting exclusively the current roster. Brute-forcing from id 1 will otherwise sweep in politicians back to Federation (1901) — exactly the Frederick Holder edge case ADR 0004 exists to dodge. Add a `WINDOW_YEARS = 50` guard: `call` returns `nil` (same as the existing empty-terms case) unless at least one Term's `entered_house`/`left_house` falls within the last 50 years. This is a no-op for every existing caller (current-roster ingest, monthly refresh) — it only changes behavior for genuinely-historical people this backfill discovers. Add a spec case to `spec/services/open_australia/ingest_person_spec.rb`.
+
+   **Date parsing: reuse, and extract, don't duplicate.** `OpenAustralia::Interpretation::RawTermDates#parse_date` already handles this exact problem (treats the `"9999-12-31"` sentinel as "still ongoing" → `nil`, handles blank/malformed dates) — don't re-derive sentinel-date logic in `IngestPerson`. But it's currently namespaced under `Interpretation`, and constraint #5 (`CONTEXT.md`) keeps Ingest free of interpretation judgment calls. Resolution: **extract the module up a level**, `OpenAustralia::Interpretation::RawTermDates` → `OpenAustralia::RawTermDates` (move `app/services/open_australia/interpretation/raw_term_dates.rb` → `app/services/open_australia/raw_term_dates.rb`), since date parsing is a shared utility, not an interpretation judgment call. Update the two existing includers (`OpenAustralia::Interpretation::ExtractPeriods`, `OpenAustralia::Interpretation::ResolvePartyAffiliations`) to the new namespace; `IngestPerson` includes it too, for the window guard only.
+
+2. **Determine the id ceiling from the live roster.** New small service `OpenAustralia::MaxKnownPersonId`, reusing the same `get_representatives`/`get_senators` calls `OpenAustralia::IngestCurrentPoliticians#roster_person_ids` already makes, returning `.map(&:to_i).max`. Current known ids run up to ~10,350 (Barnaby Joyce) — no need for precision on the floor (1), since out-of-range/no-data ids already no-op safely.
+
+3. **429 handling in `OpenAustralia::ApiClient`.** The client currently has no rate-limit handling at all (contrast `AusTender::ScrapeSingleContractAmendment`, which explicitly checks `response.status == 429`). This backfill makes ~20-30k requests (2 per id) against an API with an unknown rate limit — worth being able to tell a 429 apart from a genuine failure. Add a distinct `OpenAustraliaRateLimitError < OpenAustraliaApiError` raised on a 429 response, so it's visible in logs/`ApiLog` as its own thing. **No custom backoff** — Sidekiq's default exponential retry is enough given app-wide Sidekiq concurrency is capped at 5, so even a retry storm can't fan out into a real burst. Revisit only if the first staging run shows 429s piling up.
+
+4. **Backfill driver: `MaintenanceTasks::Task`, not a rake task.** Post-deploy backfills in this codebase always go through the `maintenance_tasks` gem (pause/resume/run-history for free), never `lib/tasks/*.rake` — confirmed convention, see `Maintenance::DedupeLobbyistPeopleTask` and `Maintenance::BackfillVicCouncilElectionResultsTask`.
+
+   Two bugs found in the first draft (modeled too literally on `BackfillVicCouncilElectionResultsTask`'s index-based delay) and their fixes:
+   - **`collection` must return an `Array` or `ActiveRecord::Relation`, not a bare `Range`.** `maintenance_tasks` is built on the `job-iteration` gem, whose enumerator builder rejects anything else. Fix: `.to_a`.
+   - **Per-item delay must not accumulate off an absolute index.** `job-iteration` calls `@task.collection` fresh on every batch of a run, including after a pause/resume — a `delay = index * SPACING` formula computed relative to run start breaks the moment a run is paused and resumed later (wildly over- or under-delays whatever resumes). Fix: a **flat** `perform_in(SPACING, person_id)` per item — spreads out a burst without assuming an uninterrupted run.
+   - **`max_person_id` must not be computed live inside `collection`.** Each job-iteration batch instantiates a new `Task`, so an instance-level `@max_person_id ||=` memo doesn't survive between batches — `collection` would hit the live roster API on every batch, and worse, a mid-run roster change would change `collection`'s size between batches, which can break cursor-based resumption (it assumes a stable, reproducible sequence). Fix, per the project owner (accepting the staleness risk, and explicitly not wanting a manual console step before starting a run): memoize at the **class** level instead of the instance level. It's computed once per Sidekiq process lifetime; a redeploy mid-run just picks up a fresh number, which is fine.
+
+   ```ruby
+   module Maintenance
+     class BackfillHistoricalPoliticiansTask < MaintenanceTasks::Task
+       SPACING = 2.seconds
+
+       def collection
+         (1..self.class.max_person_id).to_a
+       end
+       delegate :count, to: :collection
+
+       def process(person_id)
+         OpenAustralia::IngestPersonJob.perform_in(SPACING, person_id)
+       end
+
+       def self.max_person_id
+         @max_person_id ||= OpenAustralia::MaxKnownPersonId.call
+       end
+     end
+   end
+   ```
+
+   Enqueuing (not processing inline) mirrors `BackfillVicCouncilElectionResultsTask`'s reasoning: a single id's failure retries and dead-letters via Sidekiq's own machinery rather than halting the task run. Run from `/maintenance_tasks`.
+
+5. **Add `sidekiq_options(lock: :until_executed, on_conflict: :log)` to `OpenAustralia::IngestPersonJob`.** It currently has none, which is a pre-existing gap against the hard convention that any write/idempotency-sensitive job needs this lock (`sidekiq-unique-jobs` is already a dependency). Worth closing as part of this work rather than as drive-by cleanup: this backfill runs this job at far higher volume than before, and can plausibly overlap the existing monthly `IngestCurrentPoliticiansJob` re-ingesting the same ids concurrently.
+
+6. **Specs:**
+   - `ingest_person_spec.rb` — window-filtering case (above).
+   - `raw_term_dates_spec.rb` — none exists today (currently only covered indirectly via `extract_periods_spec.rb`/`resolve_party_affiliations_spec.rb`); no new requirement here, just noting the move doesn't orphan test coverage.
+   - `max_known_person_id_spec.rb` — returns the max id across both chambers' rosters.
+   - `api_client_spec.rb` — 429 response raises `OpenAustraliaRateLimitError`.
+   - `backfill_historical_politicians_task_spec.rb` — `collection` size/type; `process` enqueues `IngestPersonJob` via `perform_in` with the flat `SPACING` delay (stub the job's `perform_in`, don't let it actually enqueue — see repo convention on stubbing job enqueues in specs). The class-level `max_person_id` memo needs explicit resetting between examples that stub it differently — implementation detail, not spelled out further here.
+
+7. **Update this doc** once shipped: flip this section's status, and keep the rejected election-date-sampling approach summarized above as a permanent record (this file is never deleted per the `docs/plans/` taxonomy).
+
+### Still open
+
+- Volume: ~10-15k ids is much larger than Increment 1's one-off ~226-person run, which deliberately skipped throttling. `SPACING` above is a starting guess, not a measured value — worth watching `/maintenance_tasks` run progress and `ApiLog` error volume on the first real run (staging first) and adjusting.
 
 ---
 

--- a/spec/services/open_australia/api_client_spec.rb
+++ b/spec/services/open_australia/api_client_spec.rb
@@ -65,4 +65,12 @@ RSpec.describe OpenAustralia::ApiClient, type: :service do
       expect { client.get_representative('10007') }.to raise_error(OpenAustraliaRateLimitError, '429: slow down')
     end
   end
+
+  context 'when the API responds 200 with an error payload instead of the expected data' do
+    let(:response) { instance_double(Faraday::Response, success?: true, status: 200, body: '{"error": "Please provide an API key"}') }
+
+    it 'raises OpenAustraliaApiError instead of returning the raw error Hash' do
+      expect { client.get_representatives }.to raise_error(OpenAustraliaApiError, 'getRepresentatives: Please provide an API key')
+    end
+  end
 end

--- a/spec/services/open_australia/api_client_spec.rb
+++ b/spec/services/open_australia/api_client_spec.rb
@@ -57,4 +57,12 @@ RSpec.describe OpenAustralia::ApiClient, type: :service do
       expect { client.get_representative('10007') }.to raise_error(OpenAustraliaApiError, '500: boom')
     end
   end
+
+  context 'when the API responds with 429 Too Many Requests' do
+    let(:response) { instance_double(Faraday::Response, success?: false, status: 429, body: 'slow down') }
+
+    it 'raises OpenAustraliaRateLimitError' do
+      expect { client.get_representative('10007') }.to raise_error(OpenAustraliaRateLimitError, '429: slow down')
+    end
+  end
 end

--- a/spec/services/open_australia/ingest_person_spec.rb
+++ b/spec/services/open_australia/ingest_person_spec.rb
@@ -113,4 +113,39 @@ RSpec.describe OpenAustralia::IngestPerson, type: :service do
       expect(call).to be_nil
     end
   end
+
+  describe 'a person whose only terms predate the 50-year window (ADR 0004)' do
+    subject(:call) { described_class.call(person_id: '1') }
+
+    let(:old_term) do
+      { 'person_id' => '1', 'full_name' => 'Old Timer', 'house' => '1',
+        'entered_house' => 60.years.ago.to_date.to_s, 'left_house' => 55.years.ago.to_date.to_s }
+    end
+
+    before do
+      allow(api_client).to receive_messages(get_representative: [old_term], get_senator: [])
+    end
+
+    it 'returns nil and creates no person' do
+      expect { call }.not_to change(Person, :count)
+      expect(call).to be_nil
+    end
+  end
+
+  describe 'a person with a term inside the 50-year window but still open (still serving)' do
+    subject(:call) { described_class.call(person_id: '2') }
+
+    let(:current_term) do
+      { 'person_id' => '2', 'full_name' => 'Still Serving', 'house' => '1',
+        'entered_house' => 30.years.ago.to_date.to_s, 'left_house' => '9999-12-31' }
+    end
+
+    before do
+      allow(api_client).to receive_messages(get_representative: [current_term], get_senator: [])
+    end
+
+    it 'creates the person' do
+      expect { call }.to change(Person, :count).by(1)
+    end
+  end
 end

--- a/spec/services/open_australia/max_known_person_id_spec.rb
+++ b/spec/services/open_australia/max_known_person_id_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe OpenAustralia::MaxKnownPersonId, type: :service do
+  subject(:call) { described_class.call }
+
+  let(:api_client) { instance_double(OpenAustralia::ApiClient) }
+
+  before do
+    allow(OpenAustralia::ApiClient).to receive(:new).and_return(api_client)
+    allow(api_client).to receive_messages(
+      get_representatives: [{ 'person_id' => '100' }, { 'person_id' => '10350' }],
+      get_senators: [{ 'person_id' => '9999' }]
+    )
+  end
+
+  it 'returns the highest person_id across both chambers' do
+    expect(call).to eq(10_350)
+  end
+end

--- a/spec/tasks/maintenance/backfill_historical_politicians_task_spec.rb
+++ b/spec/tasks/maintenance/backfill_historical_politicians_task_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe Maintenance::BackfillHistoricalPoliticiansTask do
+  before do
+    described_class.instance_variable_set(:@max_person_id, nil)
+    allow(OpenAustralia::MaxKnownPersonId).to receive(:call).and_return(5)
+  end
+
+  after do
+    described_class.instance_variable_set(:@max_person_id, nil)
+  end
+
+  describe '.max_person_id' do
+    it 'memoizes OpenAustralia::MaxKnownPersonId.call at the class level' do
+      described_class.max_person_id
+      described_class.max_person_id
+
+      expect(OpenAustralia::MaxKnownPersonId).to have_received(:call).once
+    end
+  end
+
+  describe '#collection' do
+    it 'returns every person_id from 1 up to the max known id, as an Array' do
+      task = described_class.new
+
+      expect(task.collection).to eq([1, 2, 3, 4, 5])
+    end
+  end
+
+  describe '#count' do
+    it 'matches the size of the collection' do
+      task = described_class.new
+      expect(task.count).to eq(task.collection.size)
+    end
+  end
+
+  describe '#process' do
+    it 'enqueues OpenAustralia::IngestPersonJob with a flat SPACING delay' do
+      allow(OpenAustralia::IngestPersonJob).to receive(:perform_in)
+
+      described_class.new.process(3)
+
+      expect(OpenAustralia::IngestPersonJob).to have_received(:perform_in).with(described_class::SPACING, 3)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Enforces ADR 0004's 50-year window inside `OpenAustralia::IngestPerson` (nothing enforced this before — Increment 1 only achieved it as a side effect of ingesting exclusively the current roster).
- Adds `Maintenance::BackfillHistoricalPoliticiansTask` (`maintenance_tasks` gem, not a rake task) to sweep every `person_id` from 1 up to the highest id currently on the live roster, driving the existing ingest/interpret pipeline unchanged.
- Adds 429 handling (`OpenAustraliaRateLimitError`) to `OpenAustralia::ApiClient` ahead of this task's much higher request volume (~20-30k requests vs. Increment 1's ~450).
- Adds `sidekiq_options(lock: :until_executed, on_conflict: :log)` to `OpenAustralia::IngestPersonJob`, closing a pre-existing gap against this repo's hard Sidekiq-job convention, now relevant given backfill/monthly-refresh overlap risk.
- Extracts `OpenAustralia::Interpretation::RawTermDates` up to `OpenAustralia::RawTermDates`, since date parsing is a shared utility needed by both Ingest (the new window guard) and Interpretation, not an interpretation judgment call itself.

Full design writeup, including the rejected approach and the alternatives considered, is in `docs/plans/0004-ingest-federal-politicians-design.md` (Increment 4 section) — went through a `grill-me` pass that caught two real `job-iteration`/`maintenance_tasks` bugs before implementation: `collection` must return an `Array`, not a bare `Range`; and per-item enqueue delay must be flat, not accumulated off an item's position, since the task can be paused/resumed from the `/maintenance_tasks` UI.

## Test plan
- [x] `bundle exec rspec spec/services/open_australia/ spec/sidekiq/open_australia/ spec/tasks/maintenance/` — 100 examples, 0 failures
- [x] `bundle exec rubocop` on all touched files — no offenses
- [ ] Run `Maintenance::BackfillHistoricalPoliticiansTask` against staging first via `/maintenance_tasks`, watching the `low` queue and `ApiLog` for 429/error volume before letting it run to completion (per the plan doc's Verification section — `SPACING` is a starting guess, not a measured value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)